### PR TITLE
add webpack alias for vscode

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
使vscode支持webpack alias
但是不支持`vue`文件省略后缀名方式的import

比如文件路径：`./src/components/done/index.vue`
不支持如下省略
```
import done from '@/components/done'
import done from '@/components/done/index'
```
可以使用
```
import done from '@/components/done/index.vue'
```

详见：https://github.com/vuejs/vetur/issues/707