### PR TITLE
增加Action权限验证功能

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -66,3 +66,37 @@ router.beforeEach((to, from, next) => {
 router.afterEach(() => {
   NProgress.done() // finish progress bar
 })
+
+
+
+
+/**Action 权限指令**/
+const action = Vue.directive('action', {
+  bind: function (el, binding, vnode) {
+    const actionName = binding.arg
+    const roles = store.getters.roles
+    const permissionId = vnode.context.$route.meta.permission
+    let actions = []
+    roles.permissions.forEach(p => {
+      if (p.permissionId != permissionId) {
+        return
+      }
+      actions = p.actionList
+    })
+    if (actions.indexOf(actionName) < 0) {
+      setTimeout(() => {
+        if(el.parentNode == null){
+          el.style.display = 'none'
+        }
+        else{
+            el.parentNode.removeChild(el)
+        }
+      }, 10)
+
+    }
+  }
+})
+
+export {
+  action
+}


### PR DESCRIPTION
在所有操作按钮地方增加一个Vue指令 v-action:add  
add：操作名称 （可以自定义）

在roles的基础上面进行扩展的操作权限验证。判断add是否在  roles.actionList存在来验证是否有次功能的操作权限。