### PR TITLE
修正菜单路由解析

### DIFF
--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -62,7 +62,7 @@ export default {
     },
     renderMenuItem: function (h, menu, pIndex, index) {
       return h(Item, { key: menu.path ? menu.path : 'item_' + pIndex + '_' + index }, [
-        h('router-link', { attrs: { to: { name: menu.name } } }, [
+        h('router-link', { attrs: { to: { path: menu.path } } }, [
           this.renderIcon(h, menu.meta.icon),
           h('span', [menu.meta.title])
         ])


### PR DESCRIPTION
因为项目需要，菜单从服务器异步动态加载。
使用路由path参数访问菜单路径，使用name访问服务端需要配置路由路径和菜单标题，还要再配置页面客户端的路由Name，其实多余了，直接path作为访问路径，菜单的标题作为客户端展示就行了。