### PR TITLE
fix:  close popover modal, the loadding logo show and disappear

### DIFF
--- a/src/components/tools/HeaderNotice.vue
+++ b/src/components/tools/HeaderNotice.vue
@@ -1,5 +1,6 @@
 <template>
   <a-popover
+    v-model="visible"
     trigger="click"
     placement="bottomRight"
     :autoAdjustOverflow="true"
@@ -50,19 +51,21 @@ export default {
   name: 'HeaderNotice',
   data () {
     return {
-      loadding: false
+      loadding: false,
+      visible: false
     }
   },
   methods: {
     fetchNotice () {
-      if (this.loadding) {
+      if (!this.visible) {
+        this.loadding = true
+        setTimeout(() => {
+          this.loadding = false
+        }, 2000)
+      } else {
         this.loadding = false
-        return
       }
-      this.loadding = true
-      setTimeout(() => {
-        this.loadding = false
-      }, 2000)
+      this.visible = !this.visible
     }
   }
 }


### PR DESCRIPTION
修复页面头部右侧popover弹出框在等待loadding结束后关闭弹出框时会出现loadding logo出现消失现象