### PR TITLE
解决从非缓存页面返回缓存页面时重新刷新的问题

### DIFF
--- a/src/components/layouts/RouteView.vue
+++ b/src/components/layouts/RouteView.vue
@@ -5,9 +5,9 @@ export default {
     return {}
   },
   render () {
-    const { $route: { meta }, $store: { getters } } = this
+    const { $store: { getters }, aliveIgnore } = this
     const inKeep = (
-      <keep-alive>
+      <keep-alive exclude={aliveIgnore}>
         <router-view />
       </keep-alive>
     )
@@ -17,10 +17,26 @@ export default {
     // 这里增加了 multiTab 的判断，当开启了 multiTab 时
     // 应当全部组件皆缓存，否则会导致切换页面后页面还原成原始状态
     // 若确实不需要，可改为 return meta.keepAlive ? inKeep : notKeep
-    if (meta.keepAlive === false) {
-      return notKeep
+    return getters.multiTab ? inKeep : notKeep
+  },
+  methods: {
+    // 获取keepAlive为false的路由名称组成数组
+    get_ignore_route_name (routes) {
+      return routes.reduce((all, cur) => {
+        if (cur.meta && Object.is(cur.meta.keepAlive, false)) {
+          all.push(cur.name)
+        }
+        if (cur.children) {
+          all.push(...this.get_ignore_route_name(cur.children))
+        }
+        return all
+      }, [])
     }
-    return getters.multiTab || meta.keepAlive ? inKeep : notKeep
+  },
+  computed: {
+    aliveIgnore () {
+      return this.get_ignore_route_name(this.$store.getters.addRouters)
+    }
   }
 }
 </script>


### PR DESCRIPTION
从非缓存页面返回缓存页面时，所有生命周期会重新走一遍。
![image](https://user-images.githubusercontent.com/14817815/54914134-3bfcef00-4f2f-11e9-9269-d7c830e20de1.png)
应该是router-view不被keep-alive嵌套是造成的。

现在利用**keep-alive**的**exclude**属性，输入路由中meta.keepAlive为false的路由名,可解决