### PR TITLE
fix: Copping global settings in the SettingDrawer is not always the c…

### DIFF
--- a/src/components/SettingDrawer/SettingDrawer.vue
+++ b/src/components/SettingDrawer/SettingDrawer.vue
@@ -186,8 +186,7 @@ export default {
   data () {
     return {
       visible: true,
-      colorList,
-      baseConfig: Object.assign({}, config)
+      colorList
     }
   },
   watch: {
@@ -217,29 +216,27 @@ export default {
       this.visible = !this.visible
     },
     onColorWeak (checked) {
-      this.baseConfig.colorWeak = checked
       this.$store.dispatch('ToggleWeak', checked)
       updateColorWeak(checked)
     },
     onMultiTab (checked) {
-      this.baseConfig.multiTab = checked
       this.$store.dispatch('ToggleMultiTab', checked)
     },
     handleMenuTheme (theme) {
-      this.baseConfig.navTheme = theme
       this.$store.dispatch('ToggleTheme', theme)
     },
     doCopy () {
+      // get current settings from mixin or this.$store.state.app, pay attention to the property name
       const text = `export default {
-  primaryColor: '${this.baseConfig.primaryColor}', // primary color of ant design
-  navTheme: '${this.baseConfig.navTheme}', // theme for nav menu
-  layout: '${this.baseConfig.layout}', // nav menu position: sidemenu or topmenu
-  contentWidth: '${this.baseConfig.contentWidth}', // layout of content: Fluid or Fixed, only works when layout is topmenu
-  fixedHeader: ${this.baseConfig.fixedHeader}, // sticky header
-  fixSiderbar: ${this.baseConfig.fixSiderbar}, // sticky siderbar
-  autoHideHeader: ${this.baseConfig.autoHideHeader}, //  auto hide header
-  colorWeak: ${this.baseConfig.colorWeak},
-  multiTab: ${this.baseConfig.multiTab},
+  primaryColor: '${this.primaryColor}', // primary color of ant design
+  navTheme: '${this.navTheme}', // theme for nav menu
+  layout: '${this.layoutMode}', // nav menu position: sidemenu or topmenu
+  contentWidth: '${this.contentWidth}', // layout of content: Fluid or Fixed, only works when layout is topmenu
+  fixedHeader: ${this.fixedHeader}, // sticky header
+  fixSiderbar: ${this.fixSiderbar}, // sticky siderbar
+  autoHideHeader: ${this.autoHideHeader}, //  auto hide header
+  colorWeak: ${this.colorWeak},
+  multiTab: ${this.multiTab},
   production: process.env.NODE_ENV === 'production' && process.env.VUE_APP_PREVIEW !== 'true',
   // vue-ls options
   storageOptions: {
@@ -257,38 +254,30 @@ export default {
       })
     },
     handleLayout (mode) {
-      this.baseConfig.layout = mode
       this.$store.dispatch('ToggleLayoutMode', mode)
       // 因为顶部菜单不能固定左侧菜单栏，所以强制关闭
-      //
       this.handleFixSiderbar(false)
     },
     handleContentWidthChange (type) {
-      this.baseConfig.contentWidth = type
       this.$store.dispatch('ToggleContentWidth', type)
     },
     changeColor (color) {
-      this.baseConfig.primaryColor = color
       if (this.primaryColor !== color) {
         this.$store.dispatch('ToggleColor', color)
         updateTheme(color)
       }
     },
     handleFixedHeader (fixed) {
-      this.baseConfig.fixedHeader = fixed
       this.$store.dispatch('ToggleFixedHeader', fixed)
     },
     handleFixedHeaderHidden (autoHidden) {
-      this.baseConfig.autoHideHeader = autoHidden
       this.$store.dispatch('ToggleFixedHeaderHidden', autoHidden)
     },
     handleFixSiderbar (fixed) {
       if (this.layoutMode === 'topmenu') {
-        this.baseConfig.fixSiderbar = false
         this.$store.dispatch('ToggleFixSiderbar', false)
         return
       }
-      this.baseConfig.fixSiderbar = fixed
       this.$store.dispatch('ToggleFixSiderbar', fixed)
     }
   }


### PR DESCRIPTION
这个提交主要是解决配置栏中拷贝设置时复制的并不总是当前呈现的配置。
改动之前，拷贝的设置主要是从SettingDrawer.vue中的变量baseConfig中获取的，baseConfig只是默认设置的一个副本，并不总是与localStorage和store中存储的一致，比如说之前localStorage中已经存储了与默认设置不一样的改动，其后再刷新页面进入应用则此时baseConfig中的值依旧只是默认值，与配置栏中呈现的值不一致即与localStorage和store中的值不一致，此时拷贝的配置便不是当前呈现的配置。
所以改动为在配置栏中拷贝设置时直接从store中取值，保证与当前呈现的配置一致。删除变量baseConfig也避免了每次改动配置时还得同时改动baseConfig。