### PR TITLE
Feat(Layout): 允许PageView以props方式生成tabs

### DIFF
--- a/src/layouts/PageView.vue
+++ b/src/layouts/PageView.vue
@@ -72,6 +72,10 @@ export default {
     logo: {
       type: String,
       default: null
+    },
+    directTabs: {
+      type: Object,
+      default: null
     }
   },
   data () {
@@ -99,7 +103,7 @@ export default {
     getPageMeta () {
       // eslint-disable-next-line
       this.pageTitle = (typeof(this.title) === 'string' || !this.title) ? this.title : this.$route.meta.title
-
+      this.tabs = this.directTabs
       const content = this.$refs.content
       if (content) {
         if (content.pageMeta) {


### PR DESCRIPTION
## WHY
看起来目前PageView中只能通过router-view($refs.content.tabs)的方式生成tabs [代码](https://github.com/sendya/ant-design-pro-vue/blob/master/src/layouts/PageView.vue#L103-L114)
同时action好像也只能通过slot方式生成 [代码](https://github.com/sendya/ant-design-pro-vue/blob/master/src/layouts/PageView.vue#L5)
暂时不能很好满足同时需要action和tabs的场景 
## WHAT
通过向PageView注入props.directTabs的方式增强其灵活性
## HOW
``` HTML
<page-view :directTabs="tabs">
    <template slot="action">
        <a-button type="primary">通过</a-button>
    </template>
    <!-- other DOM -->
</page-view>
```
PS: tabs数据格式不变 :-)