### PR TITLE
修复当前pro版本有页面overflow 显示出浏览器滚动条时，页面会抖动一下的问题,在App.vue里面新增以后代码html::-webkit-scrollbar {display:none}，并新建一个bug-page-scroll-bar.md文件

### DIFF
--- a/docs/bug-page-scroll-bar.md
+++ b/docs/bug-page-scroll-bar.md
@@ -1,0 +1,20 @@
+解决add-page-scroll-bar.md中##写在最后浏览器滚动条时，页面会抖动一下的问题
+====
+
+
+
+## 需求
+
+> 目前 pro 有页面 overflow 显示出浏览器滚动条时，页面会抖动一下的问题。
+
+
+## 实现方案
+
+1. 在`App.vue`文件中`<style></style>`中添加以下代码
+    `html::-webkit-scrollbar {display:none}`
+2. 或者在`src\components`文件中添加以下代码
+    `html::-webkit-scrollbar {display:none}`
+
+
+## 写在最后
+争对于该问题，本人做过测试，最后采用`html::-webkit-scrollbar {display:none}`方案，不会影响html内部的滚动条样式，在移动端的tabble等，在此采用第2种方案

--- a/src/App.vue
+++ b/src/App.vue
@@ -26,4 +26,5 @@ export default {
   #app {
     height: 100%;
   }
+  html::-webkit-scrollbar {display:none}
 </style>


### PR DESCRIPTION
修复当前pro版本有页面overflow 显示出浏览器滚动条时，页面会抖动一下的问题,在App.vue里面新增以后代码html::-webkit-scrollbar {display:none}，并新建一个bug-page-scroll-bar.md文件