### PR TITLE
fix:SettingDrawer component flashes when first load

### DIFF
--- a/src/components/SettingDrawer/SettingDrawer.vue
+++ b/src/components/SettingDrawer/SettingDrawer.vue
@@ -6,6 +6,7 @@
       @close="onClose"
       :closable="false"
       :visible="visible"
+      :handle="handle"
     >
       <div class="setting-drawer-index-content">
 
@@ -183,18 +184,15 @@ export default {
   mixins: [mixin, mixinDevice],
   data () {
     return {
-      visible: true,
-      colorList
+      visible: false,
+      colorList,
+      handle: <div/>
     }
   },
   watch: {
 
   },
   mounted () {
-    const vm = this
-    setTimeout(() => {
-      vm.visible = false
-    }, 16)
     updateTheme(this.primaryColor)
     if (this.colorWeak !== config.colorWeak) {
       updateColorWeak(this.colorWeak)


### PR DESCRIPTION
原本默认设置drawer的visible为true，目的是为了让他渲染dom出来，进而显示drawer里面的按钮，然后在mounte了之后立刻把drawer关闭，这做法有点蛋疼，并且会闪了一下

drawer的handle参数可以完美解决这个问题