### PR TITLE
support ant-desgin-vue component i18n #585

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,18 +7,33 @@
 </template>
 
 <script>
+// 此处导入3钟语言，如果需要其它语言，自行导入
 import zhCN from 'ant-design-vue/lib/locale-provider/zh_CN'
+import zhTW from 'ant-design-vue/lib/locale-provider/zh_TW'
+import enUs from 'ant-design-vue/lib/locale-provider/en_US'
+import ptBR from 'ant-design-vue/lib/locale-provider/pt_BR'
 import { AppDeviceEnquire } from '@/utils/mixin'
+import { mapState } from 'vuex'
 
 export default {
   mixins: [AppDeviceEnquire],
   data () {
     return {
-      locale: zhCN
     }
   },
+  computed: {
+    ...mapState({
+      locale (state) {
+        switch (state.i18n.lang) {
+          case 'zh-CN': return zhCN
+          case 'zh-TW': return zhTW
+          case 'en-US': return enUs
+          case 'pt-BR': return ptBR
+        }
+      }
+    })
+  },
   mounted () {
-
   }
 }
 </script>

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -7,6 +7,9 @@ import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 // default language
 import enUS from './lang/en-US'
+import zhCN from './lang/zh-CN'
+import zhTW from './lang/zh-TW'
+import ptBR from './lang/pt-BR'
 // change default accept-language
 import { axios } from '@/utils/request'
 
@@ -15,9 +18,10 @@ Vue.use(VueI18n)
 export const defaultLang = 'en-US'
 
 const messages = {
-  'en-US': {
-    ...enUS
-  }
+  'en-US': { ...enUS },
+  'zh-CN': { ...zhCN },
+  'zh-TW': { ...zhTW },
+  'pt-BR': { ...ptBR }
 }
 
 const i18n = new VueI18n({


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [x] 其他改动（是关于什么的改动？）
  改动：ant-design-vue 组件的国际化支持;
  描述：为ant-design-vue 组件的国际化支持,当切换语言时，支持
### 需求背景

> 1. 描述相关需求的来源。
    这个多语言分支，在页面层面的多语言示例够用了。但咱ant-design-vue组件的多语言支持，并未作为示例
> 2. 要解决的问题。
   为了方便新手快速上手
> 3. 相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
     无影响，仅支持adv组件的国际化
> 2. 是否有可能隐含的 break change 和其他风险？
     没有

### Changelog 描述（非新功能可选）

> 1. 英文描述
      just support ant-design-for-vue components i18n
> 2. 中文描述（可选）
     只是支持ant-design-for-vue组件的国际化

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
 

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。