### PR TITLE
refactor: rename nenu as menus

### DIFF
--- a/src/components/GlobalHeader/GlobalHeader.vue
+++ b/src/components/GlobalHeader/GlobalHeader.vue
@@ -14,7 +14,7 @@
           <div class="header-index-wide">
             <div class="header-index-left">
               <logo class="top-nav-header" :show-title="device !== 'mobile'"/>
-              <s-menu v-if="device !== 'mobile'" mode="horizontal" :menu="menus" :theme="theme" />
+              <s-menu v-if="device !== 'mobile'" mode="horizontal" :menus="menus" :theme="theme" />
               <a-icon v-else class="trigger" :type="collapsed ? 'menu-fold' : 'menu-unfold'" @click="toggle" />
             </div>
             <user-menu class="header-index-right"></user-menu>

--- a/src/components/Menu/SideMenu.vue
+++ b/src/components/Menu/SideMenu.vue
@@ -8,7 +8,7 @@
     <logo />
     <s-menu
       :collapsed="collapsed"
-      :menu="menus"
+      :menus="menus"
       :theme="theme"
       :mode="mode"
       @select="onSelect"

--- a/src/components/Menu/menu.js
+++ b/src/components/Menu/menu.js
@@ -4,7 +4,7 @@ import Icon from 'ant-design-vue/es/icon'
 export default {
   name: 'SMenu',
   props: {
-    menu: {
+    menus: {
       type: Array,
       required: true
     },
@@ -34,7 +34,7 @@ export default {
   computed: {
     rootSubmenuKeys: vm => {
       const keys = []
-      vm.menu.forEach(item => keys.push(item.path))
+      vm.menus.forEach(item => keys.push(item.path))
       return keys
     }
   },
@@ -165,7 +165,7 @@ export default {
       }
     }
 
-    const menuTree = this.menu.map(item => {
+    const menuTree = this.menus.map(item => {
       if (item.hidden) {
         return null
       }


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

其它组件的props均命名为menus，只有SMenu不是。
因为是复数，理所应当为menus。
`props: { menus: { type: Array, required: true }, ... }`

### 实现方案和 API（非新功能可选）

修改menu为menus。

### 对用户的影响和可能的风险（非新功能可选）

属性名变动，可能需要修改。


> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。