### PR TITLE
修复当两个菜单权限名字高度重复时，权限判断会出错

### DIFF
--- a/src/core/directives/action.js
+++ b/src/core/directives/action.js
@@ -21,7 +21,9 @@ const action = Vue.directive('action', {
     const elVal = vnode.context.$route.meta.permission
     const permissionId = elVal instanceof String && [elVal] || elVal
     roles.permissions.forEach(p => {
-      if (!permissionId.includes(p.permissionId)) {
+      // Enda <endachao@gmail.com>
+      // if (!permissionId.includes(p.permissionId)) {
+      if (permissionId !== p.permissionId) {
         return
       }
       if (p.actionList && !p.actionList.includes(actionName)) {


### PR DESCRIPTION
### 这个变动的性质是


- 日常 bug 修复

### 需求背景

通过在实际使用中发现，v-action 判断不准确，例如：
有两个菜单的 key 与 permissionId 为
1.  system
2. systemUser

权限对应为

```
# system
"actionList": [ "add"],

# systemUser
"actionList": ["add","edit"],

```
然后在`systemUser`页面中使用  `v-action:edit`  来判断是否有修改权限，判断不成立，通过追踪代码发现问题

```
const action = Vue.directive('action', {
  inserted: function (el, binding, vnode) {
    const actionName = binding.arg
    const roles = store.getters.roles
    const elVal = vnode.context.$route.meta.permission
    const permissionId = elVal instanceof String && [elVal] || elVal
    roles.permissions.forEach(p => {
      // 此处判断并不严谨
      if (!permissionId.includes(p.permissionId)) {
        return
      }
      if (p.actionList && !p.actionList.includes(actionName)) {
        el.parentNode && el.parentNode.removeChild(el) || (el.style.display = 'none')
      }
    })
  }
})

```

在代码中，`if (!permissionId.includes(p.permissionId))` 判断并不严谨，例如上述例子

`systemUser.includes(system) ` 为 `true`, 然后因为 `system` 没有修改权限、会导致我的 Node 被移除

### 实现方案和 API（非新功能可选）

修改判断处为即可

```
if (permissionId !== p.permissionId) {
```