### PR TITLE
fixed: keep ACCESS_TOKEN header key the same

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -47,7 +47,7 @@ request.interceptors.request.use(config => {
   // 如果 token 存在
   // 让每个请求携带自定义 token 请根据实际情况自行修改
   if (token) {
-    config.headers['Access-Token'] = token
+    config.headers[ACCESS_TOKEN] = token
   }
   return config
 }, errorHandler)


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [x] 日常 bug 修复


### Changelog 描述（非新功能可选）

> 修改access_token 为其它字符串时，发送token header不一致的问题


### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供
