### PR TITLE
fix:multiple loads route

### DIFF
--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -22,6 +22,29 @@ function hasPermission (permission, route) {
 }
 
 /**
+ * 深拷贝
+ * @param obj 待拷贝的对象
+ * @returns
+ */
+function deepClone (obj) {
+  function isObject (o) {
+    return (typeof o === 'object' || typeof o === 'function') && o !== null
+  }
+
+  if (!isObject(obj)) {
+    throw new Error('Not object')
+  }
+
+  const isArray = Array.isArray(obj)
+  const newObj = isArray ? [...obj] : { ...obj }
+  Reflect.ownKeys(newObj).forEach(key => {
+    newObj[key] = isObject(obj[key]) ? deepClone(obj[key]) : obj[key]
+  })
+
+  return newObj
+}
+
+/**
  * 单账户多角色时，使用该方法可过滤角色不存在的菜单
  *
  * @param roles
@@ -65,7 +88,9 @@ const permission = {
     GenerateRoutes ({ commit }, data) {
       return new Promise(resolve => {
         const { roles } = data
-        const accessedRouters = filterAsyncRouter(asyncRouterMap, roles)
+        // 深拷贝 防止router.addRoutes() 后重新动态生成路由时 路由不完整
+        const routerMap = deepClone(asyncRouterMap)
+        const accessedRouters = filterAsyncRouter(routerMap, roles)
         commit('SET_ROUTERS', accessedRouters)
         resolve()
       })


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

问题描述：
在多次进行动态权限路由的添加时，如果前一次对路由进行过滤后，若不整页刷新，第二次动态路由过滤时的路由对象为第一次过滤后的路由对象，从而可能导致第二次需要第一次过滤掉路由时，无法正常显示，只能通过页面刷新从而恢复正常。

### 实现方案和 API（非新功能可选）

> 1. 在 src/store/modules/permission.js 里将路由重新深拷贝后在进行权限过滤

### 对用户的影响和可能的风险（非新功能可选）

> 1. 仅在静态路由文件时生效；服务端获取的动态路由可以忽视此问题。


### Changelog 描述（非新功能可选）

> 1. multiple loads route


### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

