### PR TITLE
multiple loads route

### DIFF
--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -1,4 +1,5 @@
 import { asyncRouterMap, constantRouterMap } from '@/config/router.config'
+import cloneDeep from 'lodash.clonedeep'
 
 /**
  * 过滤账户是否拥有某一个权限，并将菜单从加载列表移除
@@ -37,35 +38,6 @@ function hasRole(roles, route) {
   }
 }
 
-/**
- * 简易深拷贝
- * @param  target
- * @returns {Object}
- */
-function deepClone (target) {
-  let result
-  if (typeof target === 'object') {
-    if (Array.isArray(target)) {
-      result = []
-      for (const i in target) {
-        result.push(deepClone(target[i]))
-      }
-    } else if (target === null) {
-      result = null
-    } else if (target.constructor === RegExp) {
-      result = target
-    } else {
-      result = {}
-      for (const i in target) {
-        result[i] = deepClone(target[i])
-      }
-    }
-  } else {
-    result = target
-  }
-  return result
-}
-
 function filterAsyncRouter (routerMap, roles) {
   const accessedRouters = routerMap.filter(route => {
     if (hasPermission(roles.permissionList, route)) {
@@ -94,7 +66,7 @@ const permission = {
     GenerateRoutes ({ commit }, data) {
       return new Promise(resolve => {
         const { roles } = data
-        const routerMap = deepClone(asyncRouterMap)
+        const routerMap = cloneDeep(asyncRouterMap)
         const accessedRouters = filterAsyncRouter(routerMap, roles)
         commit('SET_ROUTERS', accessedRouters)
         resolve()

--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -37,6 +37,35 @@ function hasRole(roles, route) {
   }
 }
 
+/**
+ * 简易深拷贝
+ * @param  target
+ * @returns {Object}
+ */
+function deepClone (target) {
+  let result
+  if (typeof target === 'object') {
+    if (Array.isArray(target)) {
+      result = []
+      for (const i in target) {
+        result.push(deepClone(target[i]))
+      }
+    } else if (target === null) {
+      result = null
+    } else if (target.constructor === RegExp) {
+      result = target
+    } else {
+      result = {}
+      for (const i in target) {
+        result[i] = deepClone(target[i])
+      }
+    }
+  } else {
+    result = target
+  }
+  return result
+}
+
 function filterAsyncRouter (routerMap, roles) {
   const accessedRouters = routerMap.filter(route => {
     if (hasPermission(roles.permissionList, route)) {
@@ -65,7 +94,8 @@ const permission = {
     GenerateRoutes ({ commit }, data) {
       return new Promise(resolve => {
         const { roles } = data
-        const accessedRouters = filterAsyncRouter(asyncRouterMap, roles)
+        const routerMap = deepClone(asyncRouterMap)
+        const accessedRouters = filterAsyncRouter(routerMap, roles)
         commit('SET_ROUTERS', accessedRouters)
         resolve()
       })


### PR DESCRIPTION
First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

问题描述：
在多次进行动态权限路由的添加时，如果前一次对路由进行过滤后，若不整页刷新，第二次动态路由过滤时的路由对象为第一次过滤后的路由对象，从而可能导致第二次需要第一次过滤掉路由时，无法正常显示，只能通过页面刷新从而恢复正常。

### 实现方案和 API（非新功能可选）

> 1. 在 src/store/modules/permission.js 里将路由重新深拷贝后在进行权限过滤

### 对用户的影响和可能的风险（非新功能可选）

> 1. 仅在静态路由文件时生效；服务端获取的动态路由可以忽视此问题。


### Changelog 描述（非新功能可选）

> 1. multiple loads route


### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

