### PR TITLE
fix: 当由少权限普通用户，退出登录后重新登录超级管理员之后，左侧菜单应显示更多菜单，但目前不刷新问题，使用路由表配置时先拷贝再使用，避…

### DIFF
--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -1,5 +1,5 @@
 import { asyncRouterMap, constantRouterMap } from '@/config/router.config'
-
+import cloneDeep from "lodash.clonedeep"
 /**
  * 过滤账户是否拥有某一个权限，并将菜单从加载列表移除
  *
@@ -38,7 +38,8 @@ function hasRole(roles, route) {
 }
 
 function filterAsyncRouter (routerMap, roles) {
-  const accessedRouters = routerMap.filter(route => {
+  let routerMapCopy = cloneDeep(routerMap);
+  const accessedRouters = routerMapCopy.filter(route => {
     if (hasPermission(roles.permissionList, route)) {
       if (route.children && route.children.length) {
         route.children = filterAsyncRouter(route.children, roles)


### PR DESCRIPTION
当由少权限普通用户，退出登录后重新登录超级管理员之后，左侧菜单应显示更多菜单，但目前不刷新问题，使用路由表配置时先拷贝再使用，避免修改原路由配置

First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 描述相关需求的来源。
> 2. 要解决的问题。
    在使用pro开发时，发现当由【普通用户】，退出登录后重新登录【超级管理员】之后，用户已切换但左侧菜单却显示不出【超级管理员】新增的菜单（即不刷新，刷新页面后正常）
> 3. 相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
    使用路由表配置时先拷贝再使用，避免修改原路由配置
> 2. 列出最终的 API 实现和用法。
> 3. 涉及UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。