### PR TITLE
新增filters和sorter状态，用来保留refresh时丢失已选筛选排序bug

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -11,7 +11,11 @@ export default {
 
       localLoading: false,
       localDataSource: [],
-      localPagination: Object.assign({}, this.pagination)
+      localPagination: Object.assign({}, this.pagination),
+
+      // 存储表格onchange时的filters， sorter对象
+      filters: {},
+      sorter: {}
     }
   },
   props: Object.assign({}, T.props, {
@@ -135,7 +139,10 @@ export default {
      * @param {Object} filters 过滤条件
      * @param {Object} sorter 排序条件
      */
-    loadData (pagination, filters, sorter) {
+    loadData (pagination, filters = this.filters, sorter = this.sorter) {
+      this.filters = filters
+      this.sorter = sorter
+      
       this.localLoading = true
       const parameter = Object.assign({
         pageNo: (pagination && pagination.current) ||


### PR DESCRIPTION
由于refresh里调用loadData未穿参数，会导致调用时已选的排序等数据在请求查询接口时丢失

First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 日常 bug 修复

### 需求背景

> 1. 描述相关需求的来源。
使用过程中发现
> 2. 要解决的问题。
refresh时请求参数丢失
> 3. 相关的 issue 讨论链接。

### 实现方案和 API（非新功能可选）

> 1. 基本的解决思路和其他可选方案。
> 2. 列出最终的 API 实现和用法。
> 3. 涉及UI/交互变动需要有截图或 GIF。

### 对用户的影响和可能的风险（非新功能可选）

> 1. 这个改动对用户端是否有影响？影响的方面有哪些？
可能有影响
> 2. 是否有可能隐含的 break change 和其他风险？

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [ ] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。