### PR TITLE
After the results are obtained, the loading state of the table should always be turned off

### DIFF
--- a/src/components/Table/index.js
+++ b/src/components/Table/index.js
@@ -188,6 +188,8 @@ export default {
             this.localPagination = false
           }
           this.localDataSource = r.data // 返回结果中的数组数据
+        })
+        .finally(() => {
           this.localLoading = false
         })
       }


### PR DESCRIPTION
我认为表格的加载状态是反映这次请求有没有完成的，一旦请求完成，无论返回的结果是否成功，都应该停止表格的加载状态，而不是只有在请求成功时才停止表格的加载状态。

First of all, thank you for your contribution! 😄

Pull request will be merged after one of collaborators approve.
Please makes sure that these form are filled before submitting your pull request, thank you!


### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [x] 其他改动（是关于什么的改动？）

### 需求背景

接口返回后表格加载结束

### 实现方案和 API（非新功能可选）

1.在`finally`块中设置`localLoading`为`false`

### 对用户的影响和可能的风险（非新功能可选）

我认为没有

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供

### 后续计划（非新功能可选）

> 如果这个提交后面还有相关的其他提交和跟进信息，可以写在这里。