### PR TITLE
Separate HTTP status code and business logic status code.

### DIFF
--- a/src/mock/services/auth.js
+++ b/src/mock/services/auth.js
@@ -29,7 +29,7 @@ const login = (options) => {
     'roleId': 'admin',
     'lang': 'zh-CN',
     'token': '4291d7da9005377ec9aec4a71ea837f'
-  }, '', 200, { 'Custom-Header': Mock.mock('@guid') })
+  }, '', 200, 0, { 'Custom-Header': Mock.mock('@guid') })
 }
 
 const logout = () => {

--- a/src/mock/util.js
+++ b/src/mock/util.js
@@ -5,14 +5,16 @@ const responseBody = {
   code: 0
 }
 
-export const builder = (data, message, code = 0, headers = {}) => {
+export const builder = (data, message, status = 200, code = 0, headers = {}) => {
   responseBody.result = data
   if (message !== undefined && message !== null) {
     responseBody.message = message
   }
+  if (status !== undefined && status !== 0) {
+    responseBody._status = status
+  }
   if (code !== undefined && code !== 0) {
     responseBody.code = code
-    responseBody._status = code
   }
   if (headers !== null && typeof headers === 'object' && Object.keys(headers).length > 0) {
     responseBody._headers = headers


### PR DESCRIPTION
分离Mock中的`HTTP状态码`和`业务逻辑状态码`

目前是当设置code时，http状态码也被改为响应的code，这个不太符合逻辑，业务逻辑失败，并不应该让HTTP响应返回失败
```js
  if (code !== undefined && code !== 0) {
    responseBody.code = code
    responseBody._status = code
  }
```

### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [x] 其他改动（是关于什么的改动？）

### 需求背景

> 1. 有时候业务逻辑code和http状态码的code处理方式是不一样的，这样更灵活

### 实现方案和 API（非新功能可选）

> 1. 为`builder`函数增加`status`参数，下面是关键代码
```js
export const builder = (data, message, status = 200, code = 0, headers = {}) => {
  if (status !== undefined && status !== 0) {
    responseBody._status = status
  }
  if (code !== undefined && code !== 0) {
    responseBody.code = code
  }
}
```

### 对用户的影响和可能的风险（非新功能可选）

> 1. 没有

### Changelog 描述（非新功能可选）

> 1. 英文描述
> 2. 中文描述（可选）

### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [ ] 代码演示已提供或无须提供
- [ ] Changelog 已提供或无须提供