### PR TITLE
refactor: git config core.autocrlf以库模板形式，不需要全局配置

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
 public/* linguist-vendored
+
+# Automatically normalize line endings (to LF) for all text-based files.
+* text=auto eol=lf
+
+# Declare files that will always have CRLF line endings on checkout.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.{ico,png,jpg,jpeg,gif,webp,svg,woff,woff2} binary


### PR DESCRIPTION
### 这个变动的性质是

- [ ] 新特性提交
- [ ] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [X] 其他改动（通过仓库模板文件来配置git config）

### 需求背景

文本文件所使用的换行符，在不同的系统平台上是不一样的。团队合作、跨平台协作开发是常有的，不统一的换行符确实对跨平台的文件交换带来了麻烦。目前常用做法是全局设置 ```git config --global core.autocrlf false``` 。但是这样不是很优雅。所以在.gitattributes文件更改git config。

### 实现方案和 API（非新功能可选）

通过仓库本身来进行配置，不需要在全局配置额外指令。

如果是新仓库直接在根目录增加此文件；如果是已存在的git仓库，配置完更改后，执行git指令 ``` git add --renormalize .```。然后提交更改即可。

### 对用户的影响和可能的风险（非新功能可选）

无

### Changelog 描述（非新功能可选）

.gitattributes文件新增git config core.autocrlf相关配置。

### 请求合并前的自查清单

- [X] 文档已补充或无须补充
- [X] 代码演示已提供或无须提供
- [X] Changelog 已提供或无须提供

### 参考链接

[配置 Git 处理行结束符](https://docs.github.com/cn/get-started/getting-started-with-git/configuring-git-to-handle-line-endings)
