### PR TITLE
使this.$dialog方法调用组件异步关闭时自动触发确认按钮 loading

### DIFF
--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -17,8 +17,12 @@ export default (Vue) => {
       if (checkFunction instanceof Function) {
         const res = checkFunction()
         if (res instanceof Promise) {
+          // onOk 返回 Promise 时自动触发 loading
+          dialogInstance.changeConfirmLoading(true)
           res.then(c => {
             c && afterHandel()
+          }).finally(() => {
+            dialogInstance.changeConfirmLoading(false)
           })
         } else {
           res && afterHandel()
@@ -28,11 +32,12 @@ export default (Vue) => {
         checkFunction || afterHandel()
       }
     }
-
+    const { confirmLoading } = modalProps
     const dialogInstance = new Vue({
       data () {
         return {
-          visible: true
+          visible: true,
+          confirmLoading: !!confirmLoading
         }
       },
       router: _vm.$router,
@@ -50,6 +55,9 @@ export default (Vue) => {
             this.$refs._component.$emit('cancel')
             dialogInstance.$destroy()
           })
+        },
+        changeConfirmLoading (loading) {
+          this.confirmLoading = loading
         },
         handleOk () {
           handle(this.$refs._component.onOK || this.$refs._component.onOk, () => {
@@ -70,7 +78,8 @@ export default (Vue) => {
           attrs: Object.assign({}, {
             ...(modalProps.attrs || modalProps)
           }, {
-            visible: this.visible
+            visible: this.visible,
+            confirmLoading: this.confirmLoading
           }),
           on: Object.assign({}, {
             ...(modalProps.on || modalProps)


### PR DESCRIPTION
### 这个变动的性质是

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 文档改进
- [ ] 组件样式改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 需求背景

用户在使用 this.$dialog(Component,{},{}) 时，如果Component中onOk返回了Promise时不会触发弹框确认按钮的loading，对此进行改进

issues [讨论地址](https://github.com/vueComponent/ant-design-vue-pro/issues/838)

### 实现方案和 API（非新功能可选）

在 `dialogInstance` 实例中绑定用户传递的 `confirmLoading`，并且增加 `changeConfirmLoading` 修改 `confirmLoading` 的方法，在调用 `onOk` 时触发 `changeConfirmLoading` 方法修改 `loading` 状态

<img width="795" alt="image" src="https://user-images.githubusercontent.com/55641773/195247598-3b48fcd7-dba0-4277-8b6c-f4e422d18051.png">

<img width="812" alt="image" src="https://user-images.githubusercontent.com/55641773/195247684-6b4199d2-fa7d-42ce-b194-8af27c6ae327.png">

<img width="963" alt="image" src="https://user-images.githubusercontent.com/55641773/195247706-1b0ec5c1-5a51-499d-9bb1-f4689af8ddbf.png">


### 对用户的影响和可能的风险（非新功能可选）

内部Api对用户无影响


### 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] Changelog 已提供或无须提供

### 结果演示

![2022-10-12 12 09 15](https://user-images.githubusercontent.com/55641773/195247980-1ccaf9c3-a4c5-4c72-85bc-6cc918b9b7b7.gif)
